### PR TITLE
Send some more options to cowboy_websocket

### DIFF
--- a/lib/websock_adapter.ex
+++ b/lib/websock_adapter.ex
@@ -35,6 +35,14 @@ defmodule WebSockAdapter do
    is received the connection will be closed. Defaults to `:infinity`
   * `fullsweep_after`: The maximum number of garbage collections before forcing a fullsweep of
    the WebSocket connection process. Setting this option requires OTP 24 or newer
+  * `validate_utf8`: Whether Cowboy should verify that the payload of text and close frames is valid UTF-8.
+    This is required by the protocol specification but in some cases it may be more interesting to disable it
+    in order to save resources. Note that binary frames do not have this UTF-8 requirement and are what should be
+    used under normal circumstances if necessary.
+  * `active_n`: The number of packets Cowboy will request from the socket at once. This can be used to tweak
+    the performance of the server. Higher values reduce the number of times Cowboy need to request more
+    packets from the port driver at the expense of potentially higher memory being used.
+    This option does not apply to Websocket over HTTP/2.
   """
   @spec upgrade(Plug.Conn.t(), WebSock.impl(), WebSock.state(), [connection_opt()]) ::
           Plug.Conn.t()

--- a/lib/websock_adapter.ex
+++ b/lib/websock_adapter.ex
@@ -11,6 +11,8 @@ defmodule WebSockAdapter do
           | {:timeout, timeout()}
           | {:max_frame_size, non_neg_integer()}
           | {:fullsweep_after, non_neg_integer()}
+          | {:validate_utf8, boolean()}
+          | {:active_n, integer()}
 
   @doc """
   Upgrades the provided `Plug.Conn` connection request to a `WebSock` connection using the
@@ -50,6 +52,8 @@ defmodule WebSockAdapter do
         {:timeout, timeout} -> [idle_timeout: timeout]
         {:compress, _} = opt -> [opt]
         {:max_frame_size, _} = opt -> [opt]
+        {:validate_utf8, _}  = opt -> [opt]
+        {:active_n, _}       = opt -> [opt]
         _other -> []
       end)
       |> Map.new()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WebSockAdapter.MixProject do
   def project do
     [
       app: :websock_adapter,
-      version: "0.5.1",
+      version: "0.5.2",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
In some situations the `validate_utf8` option is very useful when switched to false.
E.g. when working with buggy clients.
Also I added sending of `active_n` option.