### PR TITLE
Add support for deflate_options configuration

### DIFF
--- a/lib/websock_adapter.ex
+++ b/lib/websock_adapter.ex
@@ -85,7 +85,7 @@ defmodule WebSockAdapter do
         {:max_frame_size, _} = opt -> [opt]
         {:validate_utf8, _} = opt -> [opt]
         {:active_n, _} = opt -> [opt]
-        {:deflate_options, _} = opt -> [deflate_opts: opt]
+        {:deflate_options, deflate_options} -> [deflate_opts: deflate_options]
         _other -> []
       end)
       |> Map.new()

--- a/lib/websock_adapter.ex
+++ b/lib/websock_adapter.ex
@@ -55,6 +55,8 @@ defmodule WebSockAdapter do
     the performance of the server. Higher values reduce the number of times Cowboy need to request more
     packets from the port driver at the expense of potentially higher memory being used.
     This option does not apply to Websocket over HTTP/2
+  * `deflate_options`: A keyword list of options to pass to the deflate library.
+    See `Bandit` or `:cow_ws` documentation for more details
   """
   @spec upgrade(Plug.Conn.t(), WebSock.impl(), WebSock.state(), [connection_opt()]) ::
           Plug.Conn.t()
@@ -83,7 +85,7 @@ defmodule WebSockAdapter do
         {:max_frame_size, _} = opt -> [opt]
         {:validate_utf8, _} = opt -> [opt]
         {:active_n, _} = opt -> [opt]
-        {:deflate_opts, _} = opt -> [opt]
+        {:deflate_options, _} = opt -> [deflate_opts: opt]
         _other -> []
       end)
       |> Map.new()

--- a/lib/websock_adapter.ex
+++ b/lib/websock_adapter.ex
@@ -83,6 +83,7 @@ defmodule WebSockAdapter do
         {:max_frame_size, _} = opt -> [opt]
         {:validate_utf8, _} = opt -> [opt]
         {:active_n, _} = opt -> [opt]
+        {:deflate_opts, _} = opt -> [opt]
         _other -> []
       end)
       |> Map.new()


### PR DESCRIPTION
This PR adds support for passing `deflate_options` to the underlying Cowboy WebSocket adapter, allowing users to configure deflate compression settings for their WebSocket connections.

## Changes

- Added `deflate_options` to the list of supported connection options in `WebSockAdapter.upgrade/4`
- Updated documentation to mention the new option
- The option is passed through to Cowboy as `deflate_opts` (matching Cowboy's expected parameter name)

## Compatibility

This change is backwards compatible as it only adds a new optional configuration parameter.