### PR TITLE
Change default `max_frame_size`

### DIFF
--- a/lib/websock_adapter.ex
+++ b/lib/websock_adapter.ex
@@ -42,7 +42,7 @@ defmodule WebSockAdapter do
   * `compress`: Whether or not to accept negotiation of a compression extension with the client.
    Defaults to `false`
   * `max_frame_size`: The maximum frame size to accept, in octets. If a frame size larger than this
-   is received the connection will be closed. Defaults to `:infinity`
+   is received the connection will be closed. Defaults to `10_000_000` (10MB)
   * `fullsweep_after`: The maximum number of garbage collections before forcing a fullsweep of
    the WebSocket connection process. Setting this option requires OTP 24 or newer
   * `max_heap_size`: The maximum size of the websocket process heap in words, or a configuration
@@ -61,6 +61,7 @@ defmodule WebSockAdapter do
   @spec upgrade(Plug.Conn.t(), WebSock.impl(), WebSock.state(), [connection_opt()]) ::
           Plug.Conn.t()
   def upgrade(%{adapter: {adapter, _}} = conn, websock, state, opts) do
+    opts = Keyword.put_new(opts, :max_frame_size, 10_000_000)
     # Do this first so we can identify unsupported adapters
     tuple = tuple_for(adapter, websock, state, opts)
 

--- a/test/websock_adapter_test.exs
+++ b/test/websock_adapter_test.exs
@@ -81,7 +81,9 @@ defmodule WebSockAdapterTest do
       |> Plug.Conn.put_req_header("sec-websocket-version", "13")
       |> WebSockAdapter.upgrade(:sock, :arg, early_validate_upgrade: false)
 
-    assert adapter.upgrade == {:websocket, {:sock, :arg, early_validate_upgrade: false}, []}
+    assert adapter.upgrade ==
+             {:websocket,
+              {:sock, :arg, max_frame_size: 10_000_000, early_validate_upgrade: false}, []}
   end
 
   test "raises an error on unknown adapter upgrade requests" do


### PR DESCRIPTION
Currently, WebSockAdapter applies a default documented limit of `:infinity` on incoming WebSocket frame size. This leaves default setups unprotected against malicious oversized payloads unless they explicitly configure `max_binary_size` on the socket transport.

(More specifically, the default value is **not** specified and is left to the underlying web servers like Bandit)

This is inconsistent with the long polling transport for Phoenix Channels, where incoming event messages are [limited to 10MB (currently hardcoded)](https://github.com/phoenixframework/phoenix/blob/ef11892fd05296a221d1cac3000b152fab226c8a/lib/phoenix/transports/long_poll.ex#L5-L6).

This PR changes the default `max_frame_size` to 10MB to match the limit already in place for long polling. Applications that need to support larger frames can opt out by raising or removing the limit explicitly.

Strictly speaking, this would be a breaking change, but then again, web socket frames >10MB are not that common. WDYT?